### PR TITLE
chore: fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/spenserca/scrub-a-dub-dub.git"
+    "url": "https://github.com/spenserca/scrub-a-dub-dub.git"
   },
   "keywords": [
     "typescript"


### PR DESCRIPTION
- make the repo url valid so semantic release can use it to deploy